### PR TITLE
Added multipart/form-data content type header to poststream requests

### DIFF
--- a/lib/VVRestApi/VVRestApiNodeJs/VVRestApi.js
+++ b/lib/VVRestApi/VVRestApiNodeJs/VVRestApi.js
@@ -646,6 +646,7 @@ var Q = require('q');
 
                 var headers = {
                     "Authorization": 'Bearer ' + this._sessionToken.accessToken,
+                    "Content-Type": "multipart/form-data"
                 };
 
                 var multipart = [];
@@ -662,9 +663,6 @@ var Q = require('q');
                 //Add file(s) to multipart data
                 if (Buffer.isBuffer(buffer)) {
                     //Single file
-                    var headers = {
-                        "Authorization": 'Bearer ' + this._sessionToken.accessToken,
-                    };
                     var filePart = {
                         'Content-Disposition': 'form-data; name="fileUpload"; filename="' + options.json.fileName + '"',
                         body: buffer,


### PR DESCRIPTION
`Content-Type` header seemed to default to `multipart/related` for POSTSTREAM requests, which caused the uploaded file to not show up in the HttpRequest.Files property on the server-side code.

From [MSDN](https://learn.microsoft.com/en-us/dotnet/api/system.web.httprequest.files?view=netframework-4.8):

> The file collection is populated only when the HTTP request Content-Type value is "multipart/form-data". 