### PR TITLE
Implement updateFolderIndexFieldOverrideSettings for libraryManager

### DIFF
--- a/lib/VVRestApi/VVRestApiNodeJs/VVRestApi.js
+++ b/lib/VVRestApi/VVRestApiNodeJs/VVRestApi.js
@@ -1175,6 +1175,22 @@ var Q = require('q');
                 return this._httpHelper.doVvClientRequest(url, opts, params, null);
             };
 
+            libraryManager.prototype.updateFolderIndexFieldOverrideSettings = function (folderId, fieldId, queryId, displayField, valueField, dropDownListId, required, defaultValue) {
+                var data = {
+                    queryId: queryId,
+                    queryValueField: valueField,
+                    queryDisplayField: displayField,
+                    dropDownListId: dropDownListId,
+                    required: required,
+                    defaultValue: defaultValue
+                }
+
+                var resourceUri = this._httpHelper._config.ResourceUri.FoldersIdIndexFieldsId.replace('{id}', folderId).replace('{indexFieldId}', fieldId);
+                var url = this._httpHelper.getUrl(resourceUri);
+                var opts = { method: 'PUT' };
+                return this._httpHelper.doVvClientRequest(url, opts, null, data);
+            };
+
             libraryManager.prototype.getFolderIndexFields = function (params, folderId) {
                 var resourceUri = this._httpHelper._config.ResourceUri.FolderIndexFields.replace('{id}', folderId);
                 var url = this._httpHelper.getUrl(resourceUri);

--- a/lib/VVRestApi/VVRestApiNodeJs/config.yml
+++ b/lib/VVRestApi/VVRestApiNodeJs/config.yml
@@ -52,6 +52,7 @@ ResourceUri:
   FoldersCopy: /folders/copy
   FoldersMove: /folders/move
   FolderIndexFields: /folders/{id}/indexfields
+  FoldersIdIndexFieldsId: /folders/{id}/indexfields/{indexFieldId}
   FolderAlertsId: /folders/{folderId}/alerts/{eventId}
   FolderSecurity: /folders/{folderId}/securitymembers
   FolderSecurityId: /folders/{folderId}/securitymembers/{memberId}


### PR DESCRIPTION
Incorporating existing method on c# client, https://github.com/VisualVault/VisualVault.Net.RestClient/blob/f8df659078c173e4e5a8fcb0f7133a20b691cc67/VVRestApi/VVRestApi/Vault/Library/FoldersManager.cs#L395
