### PR TITLE
Fix auth token refresh error and moderate refactoring

### DIFF
--- a/lib/VVRestApi/VVRestApiNodeJs/VVRestApi.js
+++ b/lib/VVRestApi/VVRestApiNodeJs/VVRestApi.js
@@ -139,52 +139,64 @@ var Q = require('q');
     })();
     vvRestApi.vvClient = vvClient;
 
-    var authorize = (function () {
-        function authorize() {
-            this.HTTP = require('http');
-            this.jsyaml = require('js-yaml');
-            this.nodeJsRequest = require('request');
-            this.Q = require('q');
-            this.fs = require('fs');
-        }
+    var auth = (function () {
+        //Pull in the authorize methods from common and extend it with the getVaultApi methods
+        var authorize = common.authorize;
 
         authorize.prototype.getVaultApi = function (clientId, clientSecret, userId, password, audience, baseVaultUrl, customerAlias, databaseAlias) {
             console.log('getVaultApi has been called');
-
+    
             // var config = require('./config.yml');
             var config = this.jsyaml.safeLoad(this.fs.readFileSync(__dirname + '/config.yml', 'utf8'));
-
+    
             if (this.endsWith(baseVaultUrl, '/')) {
                 baseVaultUrl = baseVaultUrl.substring(0, baseVaultUrl.length - 1);
             }
-
+    
             baseVaultUrl = baseVaultUrl;
-
+    
             var apiUrl = config.ApiUri.replace('{custalias}', customerAlias).replace('{custdbalias}', databaseAlias);
             var authenticationUrl = config.AutheticateUri;
-
-            return this.acquireSecurityToken(clientId, clientSecret, userId, password, audience, baseVaultUrl, apiUrl, customerAlias, databaseAlias, authenticationUrl);
+    
+            return this.acquireSecurityToken(clientId, clientSecret, userId, password, audience, baseVaultUrl, apiUrl, customerAlias, databaseAlias, authenticationUrl)
+            .then(function(sessionToken) {
+                var client = new vvClient(sessionToken);
+    
+                return client._convertToJwt(sessionToken)
+                    .then(() => {
+                        return Promise.all([
+                            client.createFormsApi(sessionToken),
+                            client.createDocApi(sessionToken)
+                        ]);
+                    })
+                    .then(() => {
+                        return client;
+                    })
+                    .catch(() => {
+                        return client;
+                    });
+                });
         };
-
+    
         authorize.prototype.getVaultApiFromJwt = function (jwt, baseVaultUrl, customerAlias, databaseAlias, expirationDate) {
             console.log('getVaultApiFromJwt has been called');
-
+    
             // var config = require('./config.yml');
             var config = this.jsyaml.safeLoad(this.fs.readFileSync(__dirname + '/config.yml', 'utf8'));
-
+    
             baseVaultUrl = baseVaultUrl;
-
+    
             if (this.endsWith(baseVaultUrl, '/')) {
                 baseVaultUrl = baseVaultUrl.substring(0, baseVaultUrl.length - 1);
             }
-
+    
             var apiUrl = config.ApiUri.replace('{custalias}', customerAlias).replace('{custdbalias}', databaseAlias);
             var authenticationUrl = apiUrl + config.ResourceUri.UsersGetJwt;
-
+    
             //Create the session token directly from JWT if the passed in expiration date is not near expiration (within next 30 seconds)
             if (expirationDate && expirationDate >= new Date(new Date().getTime() + 30 * 1000)) {
                 var sessionToken = new common.sessionToken();
-
+    
                 sessionToken.accessToken = jwt;
                 sessionToken.baseUrl = baseVaultUrl;
                 sessionToken.apiUrl = apiUrl;
@@ -194,395 +206,24 @@ var Q = require('q');
                 sessionToken.expirationDate = expirationDate;
                 sessionToken.isAuthenticated = true;
                 sessionToken.isJwt = true;
-
+    
                 var client = new vvClient(sessionToken);
                 return Promise.resolve(client);
             } else {
                 //expiration date was not passed in or is about to expire - attempt to use JWT to acquire a new JWT
-                return this.acquireJwt(jwt, baseVaultUrl, apiUrl, authenticationUrl, customerAlias, databaseAlias);
+                return this.acquireJwt(jwt, baseVaultUrl, apiUrl, authenticationUrl, customerAlias, databaseAlias).then(function(token) {
+                    return new vvClient(token);
+                });
             }
         }
-
-        authorize.prototype.acquireSecurityToken = function (clientId, clientSecret, userId, password, audience, baseUrl, apiUrl, customerAlias, databaseAlias, authenticationUrl) {
-            var self = this;
-
-            var deferred = this.Q.defer();
-
-            this.Q
-                .when(
-                    this.__getToken(
-                        clientId,
-                        clientSecret,
-                        userId,
-                        password,
-                        audience,
-                        baseUrl,
-                        customerAlias,
-                        databaseAlias,
-                        authenticationUrl,
-                        true)
-                )
-                .then(function (sessionToken) {
-
-                    console.log('acquireSecurityToken Success');
-
-                    if (typeof (sessionToken) != 'undefined' && sessionToken != null) {
-                        sessionToken.baseUrl = baseUrl;
-                        sessionToken.apiUrl = apiUrl;
-                        sessionToken.authenticationUrl = authenticationUrl;
-                        sessionToken.customerAlias = customerAlias;
-                        sessionToken.databaseAlias = databaseAlias;
-                        sessionToken.clientId = clientId;
-                        sessionToken.clientSecret = clientSecret;
-                        sessionToken.userId = userId;
-                        sessionToken.password = password;
-                        sessionToken.audience = audience;
-                        sessionToken.isAuthenticated = true;
-                    }
-
-
-                    var client = new vvClient(sessionToken);
-
-                    client._convertToJwt(sessionToken)
-                        .then(() => {
-                            Promise.all([
-                                client.createFormsApi(sessionToken),
-                                client.createDocApi(sessionToken)
-                            ]).then(() => deferred.resolve(client))
-                              .catch(() => deferred.resolve(client));
-
-                        })
-                        .catch(() => deferred.resolve(client));
-                })
-                .fail(function (error) {
-                    console.log('acquireSecurityToken Failed');
-
-                    deferred.reject(new Error(error));
-                });
-
-            return deferred.promise;
-        };
-
-        authorize.prototype.acquireJwt = function (jwt, baseUrl, apiUrl, authenticationUrl, customerAlias, databaseAlias) {
-            var self = this;
-
-            var deferred = this.Q.defer();
-
-            this.Q
-                .when(
-                    this.__getJwt(
-                        jwt,
-                        baseUrl,
-                        customerAlias,
-                        databaseAlias,
-                        authenticationUrl,
-                        true)
-                )
-                .then(function (sessionToken) {
-
-                    console.log('acquireJwt Success');
-
-                    if (typeof (sessionToken) != 'undefined' && sessionToken != null) {
-                        sessionToken.baseUrl = baseUrl;
-                        sessionToken.apiUrl = apiUrl;
-                        sessionToken.authenticationUrl = authenticationUrl;
-                        sessionToken.customerAlias = customerAlias;
-                        sessionToken.databaseAlias = databaseAlias;
-                        // sessionToken.clientId = clientId;
-                        // sessionToken.clientSecret = clientSecret;
-                        // sessionToken.userId = userId;
-                        // sessionToken.password = password;
-                        sessionToken.isAuthenticated = true;
-                        sessionToken.isJwt = true;
-                    }
-
-                    var client = new vvClient(sessionToken);
-
-                    deferred.resolve(client);
-                })
-                .fail(function (error) {
-                    console.log('acquireSecurityToken Failed');
-
-                    deferred.reject(new Error(error));
-                });
-
-            return deferred.promise;
-        }
-
-        authorize.prototype.reacquireSecurityToken = function (sessionToken) {
-            var self = this;
-
-            var deferred = this.Q.defer();
-
-            if (sessionToken.isJwt) {
-                this.Q
-                    .when(
-                        this.__getJwt(
-                            sessionToken.accessToken,
-                            sessionToken.baseUrl,
-                            sessionToken.customerAlias,
-                            sessionToken.databaseAlias,
-                            sessionToken.authenticationUrl,
-                            true
-                        )
-                    )
-                    .then(function (sessionToken) {
-                        console.log('reacquireSecurityToken Success');
-
-                        deferred.resolve(sessionToken);
-                    })
-                    .fail(function (error) {
-                        console.log('acquireSecurityToken Failed');
-
-                        deferred.reject(new Error(error));
-                    });
-            } else {
-                this.Q
-                    .when(
-                        this.__getToken(
-                            sessionToken.clientId,
-                            sessionToken.clientSecret,
-                            sessionToken.userId,
-                            sessionToken.password,
-                            sessionToken.audience,
-                            sessionToken.baseUrl,
-                            sessionToken.customerAlias,
-                            sessionToken.databaseAlias,
-                            sessionToken.authenticationUrl,
-                            true)
-                    )
-                    .then(function (sessionToken) {
-                        console.log('reacquireSecurityToken Success');
-
-                        deferred.resolve(sessionToken);
-                    })
-                    .fail(function (error) {
-                        console.log('acquireSecurityToken Failed');
-
-                        deferred.reject(new Error(error));
-                    });
-            }
-
-
-            return deferred.promise;
-        };
-
-        authorize.prototype.acquireRefreshToken = function (sessionToken) {
-            var self = this;
-
-            if (sessionToken.isJwt) {
-                return this.reacquireSecurityToken(sessionToken);
-            } else {
-                var claim = {
-                    grant_type: 'refresh_token',
-                    refresh_token: sessionToken.refreshToken,
-                    client_id: sessionToken.clientId,
-                    client_secret: sessionToken.clientSecret
-                };
-
-                if (sessionToken['audience']) {
-                    claim['audience'] = sessionToken['audience'];
-                }
-
-                console.log('In authorize.acquireRefreshToken');
-
-                var getTokenCallback = function (error, response, body) {
-
-                    if (error) {
-                        sessionToken.isAuthenticated = false;
-
-                        console.log('In authorize.acquireRefreshToken - getTokenCallback, Error from acquiring refreshToken: ' + error);
-                        logger.error('In authorize.acquireRefreshToken - getTokenCallback, Error from acquiring refreshToken: ' + error);
-
-                        deferred.reject(new Error(error));
-                    } else {
-
-
-                        if (response.statusCode == 200) {
-                            console.log('In authorize.acquireRefreshToken - getTokenCallback, Success');
-
-                            var responseObject = JSON.parse(body);
-                            sessionToken.accessToken = responseObject.access_token;
-                            sessionToken.expiresIn = responseObject.expires_in;
-                            sessionToken.refreshToken = responseObject.refresh_token;
-                            sessionToken.tokenType = responseObject.token_type;
-
-                            var expireDate = new Date();
-                            expireDate.setSeconds(expireDate.getSeconds() + sessionToken.expiresIn);
-                            //var expireSeconds = parseInt((expireDate.getTime() / 1000).toString());
-
-                            sessionToken.expirationDate = expireDate;
-                            sessionToken.isAuthenticated = true;
-
-                            deferred.resolve(sessionToken);
-                        } else if (response.statusCode == 401 || response.statusCode == 403 || response.statusCode == 400) {
-                            sessionToken.isAuthenticated = false;
-                            logger.info("In authorize.acquireRefreshToken - getTokenCallback, Authorization has been refused for current credentials. " + response.body);
-                            deferred.reject(new Error("Authorization has been refused for current credentials"));
-                        } else {
-                            sessionToken.isAuthenticated = false;
-                            console.log("In authorize.acquireRefreshToken - getTokenCallback, Unknown response for access token");
-                            logger.info("In authorize.acquireRefreshToken - getTokenCallback, Unknown response for access token");
-                            deferred.reject(new Error("Unknown response for access token"));
-                        }
-                    }
-                };
-
-                var urlSecurity = sessionToken.baseUrl + sessionToken.authenticationUrl;
-
-                console.log('In acquireRefreshToken - authenticationUrl ' + urlSecurity);
-
-                var options = { method: 'POST', uri: urlSecurity, qs: null, headers: null, form: claim };
-
-                this.nodeJsRequest(options, function (error, response, body) {
-                    getTokenCallback(error, response, body);
-                });
-
-                var deferred = this.Q.defer();
-
-                return deferred.promise;
-            }
-
-        };
-
-
-        authorize.prototype.__getToken = function (clientId, clientSecret, userId, password, audience, baseUrl, customerAlias, databaseAlias, authenticationUrl, isDebugMode) {
-            console.log('authorize.__getToken is being called');
-
-            var self = this;
-
-            var deferred = this.Q.defer();
-
-
-            var claim = {
-                grant_type: 'password',
-                client_id: clientId,
-                client_secret: clientSecret,
-                username: userId,
-                password: password,
-                scope: 'vault'
-            };
-
-            var getTokenCallback = function (error, response, body) {
-                var sessionToken = new common.sessionToken();
-
-                if (error) {
-                    sessionToken.isAuthenticated = false;
-                    console.log('Error from acquiring token: ' + error);
-                    deferred.reject(new Error(error));
-                } else {
-                    if (response.statusCode == 200) {
-                        var responseObject = JSON.parse(body);
-                        sessionToken.accessToken = responseObject.access_token;
-                        sessionToken.expiresIn = responseObject.expires_in;
-                        sessionToken.refreshToken = responseObject.refresh_token;
-                        sessionToken.tokenType = responseObject.token_type;
-
-                        var expireDate = new Date();
-                        expireDate.setSeconds(expireDate.getSeconds() + sessionToken.expiresIn);
-                        //var expireSeconds = parseInt((expireDate.getTime() / 1000).toString());
-
-                        sessionToken.expirationDate = expireDate;
-                        sessionToken.isAuthenticated = true;
-
-                        deferred.resolve(sessionToken);
-                    } else if (response.statusCode == 401 || response.statusCode == 403 || response.statusCode == 400) {
-                        sessionToken.isAuthenticated = false;
-                        logger.info("Authorization has been refused for current credentials." + response.body);
-                        deferred.reject(new Error("Authorization has been refused for current credentials"));
-                    } else {
-                        sessionToken.isAuthenticated = false;
-                        console.log("Unknown response for access token");
-                        deferred.reject(new Error("Unknown response for access token"));
-                    }
-                }
-            };
-
-            var urlSecurity = baseUrl + authenticationUrl;
-
-            console.log('authenticationUrl ' + urlSecurity);
-
-
-            var options = { method: 'POST', uri: urlSecurity, qs: null, headers: null, form: claim };
-
-            this.nodeJsRequest(options, function (error, response, body) {
-                getTokenCallback(error, response, body);
-            });
-
-            return deferred.promise;
-        };
-
-        authorize.prototype.__getJwt = function (jwt, baseUrl, customerAlias, databaseAlias, authenticationUrl, isDebugMode) {
-            console.log('authorize.__getJwt is being called');
-
-            var self = this;
-
-            var deferred = this.Q.defer();
-
-            var headers = {
-                Authorization: 'Bearer ' + jwt,
-            };
-
-
-            var getTokenCallback = function (error, response, body) {
-                var sessionToken = new common.sessionToken();
-
-                if (error) {
-                    sessionToken.isAuthenticated = false;
-                    console.log('Error from acquiring jwt: ' + error);
-                    deferred.reject(new Error(error));
-                } else {
-                    if (response.statusCode == 200) {
-                        var responseObject = JSON.parse(body);
-                        sessionToken.accessToken = responseObject.token;
-                        //sessionToken.expiresIn = responseObject.expires_in;
-                        //sessionToken.refreshToken = responseObject.refresh_token;
-                        //sessionToken.tokenType = responseObject.token_type;
-
-                        // var expireDate = new Date();
-                        // expireDate.setSeconds(expireDate.getSeconds() + sessionToken.expiresIn);
-                        //var expireSeconds = parseInt((expireDate.getTime() / 1000).toString());
-
-                        sessionToken.expirationDate = new Date(responseObject.expires);
-                        sessionToken.isAuthenticated = true;
-                        sessionToken.isJwt = true;
-
-                        deferred.resolve(sessionToken);
-                    } else if (response.statusCode == 401 || response.statusCode == 403 || response.statusCode == 400) {
-                        sessionToken.isAuthenticated = false;
-                        logger.info("Authorization has been refused for current credentials." + response.body);
-                        deferred.reject(new Error("Authorization has been refused for current credentials"));
-                    } else {
-                        sessionToken.isAuthenticated = false;
-                        console.log("Unknown response for jwt");
-                        deferred.reject(new Error("Unknown response for jwt"));
-                    }
-                }
-            };
-
-            var urlSecurity = baseUrl + authenticationUrl;
-
-            console.log('authenticationUrl ' + urlSecurity);
-
-
-            var options = { method: 'GET', uri: urlSecurity, qs: null, headers: headers };
-
-            this.nodeJsRequest(options, function (error, response, body) {
-                getTokenCallback(error, response, body);
-            });
-
-            return deferred.promise;
-        };
-
 
         authorize.prototype.endsWith = function (source, suffix) {
             return source.indexOf(suffix, source.length - suffix.length) !== -1;
         };
 
-
         return authorize;
     })();
-    vvRestApi.authorize = authorize;
+    vvRestApi.authorize = auth;
 
     (function (configuration) {
         var configurationManager = (function () {

--- a/lib/VVRestApi/VVRestApiNodeJs/common.js
+++ b/lib/VVRestApi/VVRestApiNodeJs/common.js
@@ -1,5 +1,7 @@
 const { time } = require('console');
+var common;
 
+(function (common) {
 var httpHelper = (function () {
 
     function httpHelper(sessionToken, yamlConfig) {
@@ -388,7 +390,7 @@ var httpHelper = (function () {
         var attemptCount = 0;
         this._sessionToken.isAuthenticated = false;
 
-        var vvAuthorize = new vvRestApi.authorize();
+        var vvAuthorize = new common.authorize();
 
         this.Q
             .when(
@@ -418,7 +420,7 @@ var httpHelper = (function () {
 
         var deferred = this.Q.defer();
 
-        var vvAuthorize = new vvRestApi.authorize();
+        var vvAuthorize = new common.authorize();
 
         this.Q
             .when(
@@ -448,7 +450,7 @@ var httpHelper = (function () {
     };
 
     httpHelper.prototype.__recursiveAttemptAcquireToken = function (options, requestCallback, attemptCount) {
-        var vvAuthorize = new vvRestApi.authorize();
+        var vvAuthorize = new common.authorize();
 
         this.Q
             .when(
@@ -488,7 +490,7 @@ var httpHelper = (function () {
 
     return httpHelper;
 })();
-this.httpHelper = httpHelper;
+common.httpHelper = httpHelper;
 
 var sessionToken = (function () {
     function sessionToken() {
@@ -539,7 +541,374 @@ var sessionToken = (function () {
     }
     return sessionToken;
 })();
-this.sessionToken = sessionToken;
+common.sessionToken = sessionToken;
+
+var authorize = (function () {
+    function authorize() {
+        this.HTTP = require('http');
+        this.jsyaml = require('js-yaml');
+        this.nodeJsRequest = require('request');
+        this.Q = require('q');
+        this.fs = require('fs');
+    }
+
+    authorize.prototype.acquireSecurityToken = function (clientId, clientSecret, userId, password, audience, baseUrl, apiUrl, customerAlias, databaseAlias, authenticationUrl) {
+        var self = this;
+
+        var deferred = this.Q.defer();
+
+        this.Q
+            .when(
+                this.__getToken(
+                    clientId,
+                    clientSecret,
+                    userId,
+                    password,
+                    audience,
+                    baseUrl,
+                    customerAlias,
+                    databaseAlias,
+                    authenticationUrl,
+                    true)
+            )
+            .then(function (sessionToken) {
+
+                console.log('acquireSecurityToken Success');
+
+                if (typeof (sessionToken) != 'undefined' && sessionToken != null) {
+                    sessionToken.baseUrl = baseUrl;
+                    sessionToken.apiUrl = apiUrl;
+                    sessionToken.authenticationUrl = authenticationUrl;
+                    sessionToken.customerAlias = customerAlias;
+                    sessionToken.databaseAlias = databaseAlias;
+                    sessionToken.clientId = clientId;
+                    sessionToken.clientSecret = clientSecret;
+                    sessionToken.userId = userId;
+                    sessionToken.password = password;
+                    sessionToken.audience = audience;
+                    sessionToken.isAuthenticated = true;
+                }
+
+                deferred.resolve(sessionToken);
+            })
+            .fail(function (error) {
+                console.log('acquireSecurityToken Failed');
+
+                deferred.reject(new Error(error));
+            });
+
+        return deferred.promise;
+    };
+
+    authorize.prototype.acquireJwt = function (jwt, baseUrl, apiUrl, authenticationUrl, customerAlias, databaseAlias) {
+        var self = this;
+
+        var deferred = this.Q.defer();
+
+        this.Q
+            .when(
+                this.__getJwt(
+                    jwt,
+                    baseUrl,
+                    customerAlias,
+                    databaseAlias,
+                    authenticationUrl,
+                    true)
+            )
+            .then(function (sessionToken) {
+
+                console.log('acquireJwt Success');
+
+                if (typeof (sessionToken) != 'undefined' && sessionToken != null) {
+                    sessionToken.baseUrl = baseUrl;
+                    sessionToken.apiUrl = apiUrl;
+                    sessionToken.authenticationUrl = authenticationUrl;
+                    sessionToken.customerAlias = customerAlias;
+                    sessionToken.databaseAlias = databaseAlias;
+                    // sessionToken.clientId = clientId;
+                    // sessionToken.clientSecret = clientSecret;
+                    // sessionToken.userId = userId;
+                    // sessionToken.password = password;
+                    sessionToken.isAuthenticated = true;
+                    sessionToken.isJwt = true;
+                }
+
+                deferred.resolve(sessionToken);
+            })
+            .fail(function (error) {
+                console.log('acquireSecurityToken Failed');
+
+                deferred.reject(new Error(error));
+            });
+
+        return deferred.promise;
+    }
+
+    authorize.prototype.reacquireSecurityToken = function (sessionToken) {
+        var self = this;
+
+        var deferred = this.Q.defer();
+
+        if (sessionToken.isJwt) {
+            this.Q
+                .when(
+                    this.__getJwt(
+                        sessionToken.accessToken,
+                        sessionToken.baseUrl,
+                        sessionToken.customerAlias,
+                        sessionToken.databaseAlias,
+                        sessionToken.authenticationUrl,
+                        true
+                    )
+                )
+                .then(function (sessionToken) {
+                    console.log('reacquireSecurityToken Success');
+
+                    deferred.resolve(sessionToken);
+                })
+                .fail(function (error) {
+                    console.log('acquireSecurityToken Failed');
+
+                    deferred.reject(new Error(error));
+                });
+        } else {
+            this.Q
+                .when(
+                    this.__getToken(
+                        sessionToken.clientId,
+                        sessionToken.clientSecret,
+                        sessionToken.userId,
+                        sessionToken.password,
+                        sessionToken.audience,
+                        sessionToken.baseUrl,
+                        sessionToken.customerAlias,
+                        sessionToken.databaseAlias,
+                        sessionToken.authenticationUrl,
+                        true)
+                )
+                .then(function (sessionToken) {
+                    console.log('reacquireSecurityToken Success');
+
+                    deferred.resolve(sessionToken);
+                })
+                .fail(function (error) {
+                    console.log('acquireSecurityToken Failed');
+
+                    deferred.reject(new Error(error));
+                });
+        }
+
+
+        return deferred.promise;
+    };
+
+    authorize.prototype.acquireRefreshToken = function (sessionToken) {
+        var self = this;
+
+        if (sessionToken.isJwt) {
+            return this.reacquireSecurityToken(sessionToken);
+        } else {
+            var claim = {
+                grant_type: 'refresh_token',
+                refresh_token: sessionToken.refreshToken,
+                client_id: sessionToken.clientId,
+                client_secret: sessionToken.clientSecret
+            };
+
+            if (sessionToken['audience']) {
+                claim['audience'] = sessionToken['audience'];
+            }
+
+            console.log('In authorize.acquireRefreshToken');
+
+            var getTokenCallback = function (error, response, body) {
+
+                if (error) {
+                    sessionToken.isAuthenticated = false;
+
+                    console.log('In authorize.acquireRefreshToken - getTokenCallback, Error from acquiring refreshToken: ' + error);
+                    logger.error('In authorize.acquireRefreshToken - getTokenCallback, Error from acquiring refreshToken: ' + error);
+
+                    deferred.reject(new Error(error));
+                } else {
+
+
+                    if (response.statusCode == 200) {
+                        console.log('In authorize.acquireRefreshToken - getTokenCallback, Success');
+
+                        var responseObject = JSON.parse(body);
+                        sessionToken.accessToken = responseObject.access_token;
+                        sessionToken.expiresIn = responseObject.expires_in;
+                        sessionToken.refreshToken = responseObject.refresh_token;
+                        sessionToken.tokenType = responseObject.token_type;
+
+                        var expireDate = new Date();
+                        expireDate.setSeconds(expireDate.getSeconds() + sessionToken.expiresIn);
+                        //var expireSeconds = parseInt((expireDate.getTime() / 1000).toString());
+
+                        sessionToken.expirationDate = expireDate;
+                        sessionToken.isAuthenticated = true;
+
+                        deferred.resolve(sessionToken);
+                    } else if (response.statusCode == 401 || response.statusCode == 403 || response.statusCode == 400) {
+                        sessionToken.isAuthenticated = false;
+                        logger.info("In authorize.acquireRefreshToken - getTokenCallback, Authorization has been refused for current credentials. " + response.body);
+                        deferred.reject(new Error("Authorization has been refused for current credentials"));
+                    } else {
+                        sessionToken.isAuthenticated = false;
+                        console.log("In authorize.acquireRefreshToken - getTokenCallback, Unknown response for access token");
+                        logger.info("In authorize.acquireRefreshToken - getTokenCallback, Unknown response for access token");
+                        deferred.reject(new Error("Unknown response for access token"));
+                    }
+                }
+            };
+
+            var urlSecurity = sessionToken.baseUrl + sessionToken.authenticationUrl;
+
+            console.log('In acquireRefreshToken - authenticationUrl ' + urlSecurity);
+
+            var options = { method: 'POST', uri: urlSecurity, qs: null, headers: null, form: claim };
+
+            this.nodeJsRequest(options, function (error, response, body) {
+                getTokenCallback(error, response, body);
+            });
+
+            var deferred = this.Q.defer();
+
+            return deferred.promise;
+        }
+
+    };
+
+
+    authorize.prototype.__getToken = function (clientId, clientSecret, userId, password, audience, baseUrl, customerAlias, databaseAlias, authenticationUrl, isDebugMode) {
+        console.log('authorize.__getToken is being called');
+
+        var self = this;
+
+        var deferred = this.Q.defer();
+
+
+        var claim = {
+            grant_type: 'password',
+            client_id: clientId,
+            client_secret: clientSecret,
+            username: userId,
+            password: password,
+            scope: 'vault'
+        };
+
+        var getTokenCallback = function (error, response, body) {
+            var sessionToken = new common.sessionToken();
+
+            if (error) {
+                sessionToken.isAuthenticated = false;
+                console.log('Error from acquiring token: ' + error);
+                deferred.reject(new Error(error));
+            } else {
+                if (response.statusCode == 200) {
+                    var responseObject = JSON.parse(body);
+                    sessionToken.accessToken = responseObject.access_token;
+                    sessionToken.expiresIn = responseObject.expires_in;
+                    sessionToken.refreshToken = responseObject.refresh_token;
+                    sessionToken.tokenType = responseObject.token_type;
+
+                    var expireDate = new Date();
+                    expireDate.setSeconds(expireDate.getSeconds() + sessionToken.expiresIn);
+                    //var expireSeconds = parseInt((expireDate.getTime() / 1000).toString());
+
+                    sessionToken.expirationDate = expireDate;
+                    sessionToken.isAuthenticated = true;
+
+                    deferred.resolve(sessionToken);
+                } else if (response.statusCode == 401 || response.statusCode == 403 || response.statusCode == 400) {
+                    sessionToken.isAuthenticated = false;
+                    logger.info("Authorization has been refused for current credentials." + response.body);
+                    deferred.reject(new Error("Authorization has been refused for current credentials"));
+                } else {
+                    sessionToken.isAuthenticated = false;
+                    console.log("Unknown response for access token");
+                    deferred.reject(new Error("Unknown response for access token"));
+                }
+            }
+        };
+
+        var urlSecurity = baseUrl + authenticationUrl;
+
+        console.log('authenticationUrl ' + urlSecurity);
+
+
+        var options = { method: 'POST', uri: urlSecurity, qs: null, headers: null, form: claim };
+
+        this.nodeJsRequest(options, function (error, response, body) {
+            getTokenCallback(error, response, body);
+        });
+
+        return deferred.promise;
+    };
+
+    authorize.prototype.__getJwt = function (jwt, baseUrl, customerAlias, databaseAlias, authenticationUrl, isDebugMode) {
+        console.log('authorize.__getJwt is being called');
+
+        var self = this;
+
+        var deferred = this.Q.defer();
+
+        var headers = {
+            Authorization: 'Bearer ' + jwt,
+        };
+
+
+        var getTokenCallback = function (error, response, body) {
+            var sessionToken = new common.sessionToken();
+
+            if (error) {
+                sessionToken.isAuthenticated = false;
+                console.log('Error from acquiring jwt: ' + error);
+                deferred.reject(new Error(error));
+            } else {
+                if (response.statusCode == 200) {
+                    var responseObject = JSON.parse(body);
+                    
+                    sessionToken.accessToken = responseObject.data.token;
+                    sessionToken.expirationDate = new Date(responseObject.data.expires);
+                    sessionToken.isAuthenticated = true;
+                    sessionToken.isJwt = true;
+
+                    deferred.resolve(sessionToken);
+                } else if (response.statusCode == 401 || response.statusCode == 403 || response.statusCode == 400) {
+                    sessionToken.isAuthenticated = false;
+                    logger.info("Authorization has been refused for current credentials." + response.body);
+                    deferred.reject(new Error("Authorization has been refused for current credentials"));
+                } else {
+                    sessionToken.isAuthenticated = false;
+                    console.log("Unknown response for jwt");
+                    deferred.reject(new Error("Unknown response for jwt"));
+                }
+            }
+        };
+
+        var urlSecurity = baseUrl + authenticationUrl;
+
+        console.log('authenticationUrl ' + urlSecurity);
+
+
+        var options = { method: 'GET', uri: urlSecurity, qs: null, headers: headers };
+
+        this.nodeJsRequest(options, function (error, response, body) {
+            getTokenCallback(error, response, body);
+        });
+
+        return deferred.promise;
+    };
+
+
+    
+
+
+    return authorize;
+})();
+common.authorize = authorize;
 
 (function (services) {
     var apiServiceCoreSettings = (function () {
@@ -549,7 +918,7 @@ this.sessionToken = sessionToken;
             this.Signers = {};
             this.XML = {};
 
-            this.util = new vvRestApi.common.services.serviceCoreUtility(this);
+            this.util = new this.services.serviceCoreUtility(this);
         }
         return apiServiceCoreSettings;
     })();
@@ -980,7 +1349,7 @@ this.sessionToken = sessionToken;
 
     var httpRequest = (function () {
         function httpRequest(currentEndpoint, region, method, currentHeaders, data, util) {
-            currentEndpoint = new vvRestApi.common.services.endpoint(currentEndpoint, util);
+            currentEndpoint = new this.services.endpoint(currentEndpoint, util);
             this.method = method.toUpperCase();
             this.path = currentEndpoint.path || '/';
             this.headers = {};
@@ -1222,5 +1591,7 @@ this.sessionToken = sessionToken;
 })(this.services || (this.services = {}));
 var services = this.services;
 
+ }) (common || (common = {}));
 
+module.exports = common;
 


### PR DESCRIPTION
Moved security token methods from VVRestAPI.js into common.js to allow httphelper to refresh auth tokens when they're about to expire.

Altered acquireSecurityToken method to return the session token instead of a new vvClient object. Modified getVaultApi and getValutApiFromJwt methods to be responsible for instantiating returning a new vvClient object.