### PR TITLE
Allow parallel file downloads

### DIFF
--- a/lib/VVRestApi/VVRestApiNodeJs/common.js
+++ b/lib/VVRestApi/VVRestApiNodeJs/common.js
@@ -164,7 +164,7 @@ var httpHelper = (function () {
         var stream = require('stream');
         var bf = require('buffer');
 
-        var Duplex = stream.Duplex;
+        var Duplex = new stream.Duplex;
         var requestDefer = this.Q.defer();
         var request = this.nodeJsRequest(options, (error, response, body) => {
             error ? requestDefer.resolve(error) : requestDefer.resolve(body);


### PR DESCRIPTION
Adding the "new" keyword to stream.Duplex allows for each file download to use a new class object instead of reusing the same one, avoiding the cancelation of a file download if there are multiple ocurring at the same time.