### PR TITLE
Add multi-IP DNS failover to the shared VisualVault HTTP client

### DIFF
--- a/lib/VVRestApi/VVRestApiNodeJs/common.js
+++ b/lib/VVRestApi/VVRestApiNodeJs/common.js
@@ -1,5 +1,6 @@
 const { time } = require('console');
 var logger = require('./log');
+var httpAgentHelper = require('./httpAgent');
 var common;
 
 (function (common) {
@@ -147,22 +148,30 @@ var httpHelper = (function () {
 
         console.log("In __makeRequest - Performing request to url:" + url);
 
-        this.nodeJsRequest(options,
+        httpAgentHelper.requestWithRetry(this.nodeJsRequest, options,
             function (error, response, body) {
                 requestCallback(error, response, body);
-            }
+            },
+            this._maxRetries
         );
     };
 
     // request for stream
-    httpHelper.prototype.__makeStreamRequest = function (url, options, requestCallback) {
+    httpHelper.prototype.__makeStreamRequest = function (url, options, requestCallback, retries) {
         options.headers["Authorization"] = 'Bearer ' + this._sessionToken.accessToken;
         options.headers["Content-Type"] = 'application/json; charset=utf-8';
+
+        if (!options.agent) {
+            options.agent = httpAgentHelper.agentForUrl(url);
+        }
 
         console.log("In __makeStreamRequest - Performing request to url:" + url);
         var fs = require('fs');
         var stream = require('stream');
         var bf = require('buffer');
+        var self = this;
+
+        retries = retries || 0;
 
         var Duplex = new stream.Duplex;
         var requestDefer = this.Q.defer();
@@ -171,6 +180,22 @@ var httpHelper = (function () {
         });
         Duplex.Readable = request;
         var bufs = [];
+
+        // Connection-level failures (e.g. the resolved IP isn't responding)
+        // surface as an 'error' event before any 'data'/'end' fires. Retry
+        // against a freshly re-resolved IP rather than leaving the caller's
+        // promise hanging forever.
+        Duplex.Readable.on('error', function (error) {
+            if (httpAgentHelper.isRetryableConnectionError(error) && retries < self._maxRetries) {
+                retries++;
+                console.log('Connection error (' + error.code + ') streaming ' + url + ' - retrying, attempt ' + retries + ' of ' + self._maxRetries);
+                setTimeout(function () {
+                    self.__makeStreamRequest(url, options, requestCallback, retries);
+                }, 250 * retries);
+            } else {
+                requestCallback(error, 500, error.message);
+            }
+        });
 
         Duplex.Readable.on('data', function (chunk) {
             console.log('got %d bytes of data', chunk.length);
@@ -263,17 +288,21 @@ var httpHelper = (function () {
         }
 
         //Make request
-        streamRequest({
+        var postStreamOptions = {
             method: options.method,
             preambleCRLF: true,
             postambleCRLF: true,
             uri: url,
             multipart: multipart,
-            headers: headers
-        },
+            headers: headers,
+            agent: httpAgentHelper.agentForUrl(url)
+        };
+
+        httpAgentHelper.requestWithRetry(streamRequest, postStreamOptions,
             function (error, response, body) {
                 return requestCallback(error, response, body);
-            }
+            },
+            this._maxRetries
         );
     };
 
@@ -388,6 +417,7 @@ var httpHelper = (function () {
     };
 
     httpHelper.prototype.__acquireNewTokenWithRequest = function (options, requestCallback) {
+        var self = this;
         var attemptCount = 0;
         this._sessionToken.isAuthenticated = false;
 
@@ -400,17 +430,20 @@ var httpHelper = (function () {
             .then(
                 function (result) {
 
-                    options.headers["Authorization"] = 'Bearer ' + this._sessionToken.accessToken;
+                    options.headers["Authorization"] = 'Bearer ' + self._sessionToken.accessToken;
 
-                    this.nodeJsRequest(options, function (error, response, body) {
-                        requestCallback(error, response, body);
+                    if (!options.agent) {
+                        options.agent = httpAgentHelper.agentForUrl(options.uri || options.url);
                     }
-                    );
+
+                    httpAgentHelper.requestWithRetry(self.nodeJsRequest, options, function (error, response, body) {
+                        requestCallback(error, response, body);
+                    }, self._maxRetries);
                 }
             )
             .fail(
                 function (tokenError) {
-                    vvAuthorize.acquireSecurityToken(this._sessionToken)
+                    vvAuthorize.acquireSecurityToken(self._sessionToken)
                 }
             );
     };
@@ -451,6 +484,7 @@ var httpHelper = (function () {
     };
 
     httpHelper.prototype.__recursiveAttemptAcquireToken = function (options, requestCallback, attemptCount) {
+        var self = this;
         var vvAuthorize = new common.authorize();
 
         this.Q
@@ -459,16 +493,20 @@ var httpHelper = (function () {
             .then(function (result) {
                 var sessionToken = result;
 
-                options.headers["Authorization"] = 'Bearer ' + this._sessionToken.accessToken;
+                options.headers["Authorization"] = 'Bearer ' + self._sessionToken.accessToken;
 
-                this.nodeJsRequest(options, function (error, response, body) {
+                if (!options.agent) {
+                    options.agent = httpAgentHelper.agentForUrl(options.uri || options.url);
+                }
+
+                httpAgentHelper.requestWithRetry(self.nodeJsRequest, options, function (error, response, body) {
                     requestCallback(error, response, body);
-                });
+                }, self._maxRetries);
             })
             .fail(function (tokenError) {
                 if (attemptCount < 6) {
                     attemptCount++;
-                    this.__recursiveAttemptAcquireToken(options, requestCallback, attemptCount);
+                    self.__recursiveAttemptAcquireToken(options, requestCallback, attemptCount);
                 }
             });
     };
@@ -551,6 +589,7 @@ var authorize = (function () {
         this.nodeJsRequest = require('request');
         this.Q = require('q');
         this.fs = require('fs');
+        this._maxRetries = 3;
     }
 
     authorize.prototype.acquireSecurityToken = function (clientId, clientSecret, userId, password, audience, baseUrl, apiUrl, customerAlias, databaseAlias, authenticationUrl) {
@@ -768,11 +807,11 @@ var authorize = (function () {
 
             console.log('In acquireRefreshToken - authenticationUrl ' + urlSecurity);
 
-            var options = { method: 'POST', uri: urlSecurity, qs: null, headers: null, form: claim };
+            var options = { method: 'POST', uri: urlSecurity, qs: null, headers: null, form: claim, agent: httpAgentHelper.agentForUrl(urlSecurity) };
 
-            this.nodeJsRequest(options, function (error, response, body) {
+            httpAgentHelper.requestWithRetry(this.nodeJsRequest, options, function (error, response, body) {
                 getTokenCallback(error, response, body);
-            });
+            }, this._maxRetries);
 
             var deferred = this.Q.defer();
 
@@ -839,11 +878,11 @@ var authorize = (function () {
         console.log('authenticationUrl ' + urlSecurity);
 
 
-        var options = { method: 'POST', uri: urlSecurity, qs: null, headers: null, form: claim };
+        var options = { method: 'POST', uri: urlSecurity, qs: null, headers: null, form: claim, agent: httpAgentHelper.agentForUrl(urlSecurity) };
 
-        this.nodeJsRequest(options, function (error, response, body) {
+        httpAgentHelper.requestWithRetry(this.nodeJsRequest, options, function (error, response, body) {
             getTokenCallback(error, response, body);
-        });
+        }, this._maxRetries);
 
         return deferred.promise;
     };
@@ -894,17 +933,17 @@ var authorize = (function () {
         console.log('authenticationUrl ' + urlSecurity);
 
 
-        var options = { method: 'GET', uri: urlSecurity, qs: null, headers: headers };
+        var options = { method: 'GET', uri: urlSecurity, qs: null, headers: headers, agent: httpAgentHelper.agentForUrl(urlSecurity) };
 
-        this.nodeJsRequest(options, function (error, response, body) {
+        httpAgentHelper.requestWithRetry(this.nodeJsRequest, options, function (error, response, body) {
             getTokenCallback(error, response, body);
-        });
+        }, this._maxRetries);
 
         return deferred.promise;
     };
 
 
-    
+
 
 
     return authorize;

--- a/lib/VVRestApi/VVRestApiNodeJs/httpAgent.js
+++ b/lib/VVRestApi/VVRestApiNodeJs/httpAgent.js
@@ -1,0 +1,62 @@
+var http = require('http');
+var https = require('https');
+var CacheableLookup = require('cacheable-lookup');
+
+// AWS ALB/ELB DNS names resolve to multiple IPs and rotate which ones are
+// returned over time. cacheable-lookup resolves every A/AAAA record for a
+// host and round-robins across them on each lookup, so a fresh connection
+// attempt after a failure is likely to land on a different IP than the one
+// that just failed.
+var cacheableLookup = new CacheableLookup();
+
+var httpsAgent = new https.Agent({ keepAlive: true, lookup: cacheableLookup.lookup });
+var httpAgent = new http.Agent({ keepAlive: true, lookup: cacheableLookup.lookup });
+
+var RETRYABLE_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ENOTFOUND', 'EHOSTUNREACH', 'EAI_AGAIN'];
+
+function agentForUrl(url) {
+    return typeof url === 'string' && url.indexOf('https:') === 0 ? httpsAgent : httpAgent;
+}
+
+function isRetryableConnectionError(error) {
+    if (!error) {
+        return false;
+    }
+    var code = error.code || (error.cause && error.cause.code);
+    return RETRYABLE_CODES.indexOf(code) !== -1;
+}
+
+// Wraps a `request`-style call (fn(options, callback)) with retries on
+// connection-level failures (the node never responded at all, as opposed to
+// an HTTP-level error response). Assigns a keep-alive agent using the
+// cacheable-lookup resolver above if the caller hasn't already set one.
+function requestWithRetry(requestFn, options, callback, maxRetries) {
+    if (!options.agent) {
+        options.agent = agentForUrl(options.uri || options.url);
+    }
+
+    var retries = typeof maxRetries === 'number' ? maxRetries : 3;
+    var attempt = 0;
+
+    function attemptRequest() {
+        requestFn(options, function (error, response, body) {
+            if (error && isRetryableConnectionError(error) && attempt < retries) {
+                attempt++;
+                console.log('Connection error (' + error.code + ') calling ' + (options.uri || options.url) + ' - retrying, attempt ' + attempt + ' of ' + retries);
+                setTimeout(attemptRequest, 250 * attempt);
+            } else {
+                callback(error, response, body);
+            }
+        });
+    }
+
+    attemptRequest();
+}
+
+module.exports = {
+    httpAgent: httpAgent,
+    httpsAgent: httpsAgent,
+    agentForUrl: agentForUrl,
+    isRetryableConnectionError: isRetryableConnectionError,
+    requestWithRetry: requestWithRetry
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "visualvault-nodejs-client-library",
-  "version": "1.1.0",
+  "name": "visualvault-api",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "visualvault-nodejs-client-library",
-      "version": "1.1.0",
+      "name": "visualvault-api",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-comprehend": "^3.418.0",
@@ -15,6 +15,7 @@
         "aws-sdk": "^2.1472.0",
         "axios": "^1.9.0",
         "body-parser": "^1.18.3",
+        "cacheable-lookup": "^6.1.0",
         "cors": "^2.8.5",
         "cross-fetch": "^3.1.4",
         "csv": "^4.0.0",
@@ -61,6 +62,9 @@
         "winston": "^2.4.2",
         "winston-cloudwatch": "^1.13.1",
         "winston-cloudwatch-transport": "^1.0.8"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3355,6 +3359,15 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
       }
     },
     "node_modules/call-bind": {
@@ -13808,6 +13821,11 @@
           "optional": true
         }
       }
+    },
+    "cacheable-lookup": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww=="
     },
     "call-bind": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "aws-sdk": "^2.1472.0",
     "axios": "^1.9.0",
     "body-parser": "^1.18.3",
+    "cacheable-lookup": "^6.1.0",
     "cors": "^2.8.5",
     "cross-fetch": "^3.1.4",
     "csv": "^4.0.0",


### PR DESCRIPTION
## Summary
- The shared `httpHelper`/`authorize` transport in `lib/VVRestApi/VVRestApiNodeJs/common.js` (used by nearly every server/scheduled script via `vvClient`) had no keep-alive agent, no custom DNS resolution, and no retry on connection-level failures.
- AWS ALB DNS entries resolve to multiple IPs that change over time. Without this, a request that hits an IP that isn't responding just fails outright — and for stream downloads, the promise silently hangs forever with no callback at all.
- Adds `lib/VVRestApi/VVRestApiNodeJs/httpAgent.js`: uses `cacheable-lookup` (pinned to v6.1.0, the last CommonJS-compatible major — v7 is ESM-only) to resolve and round-robin across every IP behind a hostname, plus a `requestWithRetry` helper that retries `ECONNREFUSED`/`ECONNRESET`/`ETIMEDOUT`/`ENOTFOUND`/etc. up to `_maxRetries` (3, matching the existing 429-retry cap) with a short backoff — since each retry re-resolves via the round-robin cache, it's likely to land on a different IP than the one that just failed.
- Wired into every `request()` call site in `common.js`: CRUD (`__makeRequest`), file upload (`__makePostStreamRequest`), file download streaming (`__makeStreamRequest` — also fixes the hang-forever bug on connection failure), and all OAuth token acquisition/refresh paths (`__getToken`, `__getJwt`, `acquireRefreshToken`, plus two already-broken `this`-binding dead-code paths that are fixed as a side effect of the same edit).
- Scope: intentionally limited to the shared client. Two scripts (`VerifyAddress.js`, `TestSMSMessage.js`) make their own raw `https.request()` calls to a separate email/SMS microservice and were left untouched per discussion.

## Test plan
- [x] `node -e "require(...)"` sanity-loads `common.js`/`VVRestApi.js` with no syntax/runtime errors.
- [x] Standalone test of `httpAgent.js`: error classification, http/https agent selection, retry-until-success (mocked `ECONNREFUSED` x2 then success), and retry-exhaustion (mocked persistent `ETIMEDOUT` surfaces the error after `maxRetries`).
- [ ] Manual verification against a real VisualVault ALB-backed endpoint (not exercised here — no live credentials/network in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)